### PR TITLE
check for s

### DIFF
--- a/naturalSort.js
+++ b/naturalSort.js
@@ -23,7 +23,7 @@ function naturalSort (a, b) {
         yD = parseInt(y.match(hre), 16) || xD && y.match(dre) && Date.parse(y) || null,
         normChunk = function(s, l) {
             // normalize spaces; find floats not starting with '0', string or 0 if not defined (Clint Priest)
-            if (!s) return 0;
+            if (typeof s === 'undefined') return 0;
             return (!s.match(ore) || l == 1) && parseFloat(s) || s.replace(snre, ' ').replace(sre, '') || 0;
         },
         oFxNcL, oFyNcL;

--- a/naturalSort.js
+++ b/naturalSort.js
@@ -23,6 +23,7 @@ function naturalSort (a, b) {
         yD = parseInt(y.match(hre), 16) || xD && y.match(dre) && Date.parse(y) || null,
         normChunk = function(s, l) {
             // normalize spaces; find floats not starting with '0', string or 0 if not defined (Clint Priest)
+            if (!s) return 0;
             return (!s.match(ore) || l == 1) && parseFloat(s) || s.replace(snre, ' ').replace(sre, '') || 0;
         },
         oFxNcL, oFyNcL;


### PR DESCRIPTION
If I try to compare two strings:

```
'SomeString'
'SomeString 1'
```

in the for loop in naturalSort (line 36 in my branch), it will attempt to call normalChunk on these arrays:

```
['SomeString']
['SomeString', '1']
```

When it calls xn[cLoc], where cLoc = 1, that will be undefined. the normChunk function will then try to do a .match on undefined, bombing out. This checks for that undefined property.